### PR TITLE
Correct order like an AWS Console

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,7 +102,8 @@ func main() {
 		w.Write([]byte(fmt.Sprintf("%s\t%d\t%d\t%d\t%s\n",
 			aws.StringValue(asg.AutoScalingGroupName),
 			aws.Int64Value(asg.DesiredCapacity),
-			aws.Int64Value(asg.MaxSize), aws.Int64Value(asg.MinSize),
+			aws.Int64Value(asg.MinSize),
+			aws.Int64Value(asg.MaxSize),
 			aws.StringValue(asg.LaunchConfigurationName))),
 		)
 	}


### PR DESCRIPTION
Label or AWS Console order is below, but result data was incorrect orders.
```
autoscaling-group-name          desired    min    max    Launch-configuration-name
```